### PR TITLE
consistency to log messages

### DIFF
--- a/src/modules/close.js
+++ b/src/modules/close.js
@@ -71,7 +71,7 @@ module.exports = (bot, sse) => {
 
     const logUrl = await thread.getLogUrl();
     utils.postLog(utils.trimAll(`
-      Modmail thread with ${thread.user_name} (${thread.user_id}) was closed by ${msg.author.username}
+      Modmail thread with ${thread.user_name} (${thread.user_id}) was closed by ${msg.author.username}#${msg.author.discriminator}
       Logs: <${logUrl}>
     `));
   });


### PR DESCRIPTION
!close with a time would say "Modmail thread with x#0000 (id) was closed as scheduled by mod#0000"
!close without a time would not include discriminator, "Modmail thread with x#0000 (id) was closed by mod"
changed close w/out time to use discriminator as well to preserve continuity